### PR TITLE
Update to Fedora 35

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,17 @@ Clone the repository and then simply run with the following additional args
 added to the `vagrant` command:
 
 
-* `--instances`: The number of Keylime Virtual Machines to create. If not provided, it defaults to `1`
-* `--repo`: This mounts your local Keylime git repository into the virtual machine (allowing you to test your code within the VM). This is optional.
-* `--cpus`: The amount of CPU's. If not provided, it defaults to `2`
-* `--memory`: The amount of memory to assign.  If not provided, it defaults to `2048`
-* `--qualityoflife`: Adds a few extras, such as the Powerline improved bash shell
-   prompt as well as an ls alias (ll for ls -lAh). This is optional.
+* `--instances`: The number of Keylime virtual machines to create. If not
+  provided, it defaults to `1`
+* `--repo`: This is intended to help you hack on Keylime. It mounts a local
+Keylime Git repository into the virtual machine, allowing you to test your code
+within the VM. This is optional and will mount the repo directory you pass in
+at "/root/keylime-dev".
+* `--cpus`: The number of CPUs. If not provided, defaults to `2`
+* `--memory`: The amount of memory to assign.  If not provided, defaults to
+  `2048`
+* `--qualityoflife`: Adds a few extras, such as the Powerline improved bash
+  shell prompt as well as an ls alias (ll for ls -lAh). This is optional.
 
 Deployment example, using libvirt as the virtualization provider:
 
@@ -92,6 +97,11 @@ keylime_agent
 
 keylime_node
 ```
+
+Note: you will most likely need to export the right TPM2TOOLS_TCTI environment
+variable before being able to successfully start keylime_agent. To do so:
+`export TPM2TOOLS_TCTI="mssim:port=2321"`
+
 ### Upgrading VMs
 
 If you just want to upgrade Keylime within your VM(s), running the following as
@@ -127,7 +137,8 @@ This role deploys a basic ima-policy into `/etc/ima/ima-policy` so that IMA
 run time integrity may be used. For this to activate, you must reboot the
 machine first (if you're using vagrant, perform `vagrant reload`)
 
-Should you reboot the machine, you will need to start the emulator again:
+### Obsolete, as we don't use abrmd anymore
+Previously, when rebooting the machine, one needed to start the emulator again:
 
 `/usr/local/bin/tpm_serverd`
 
@@ -137,7 +148,14 @@ Once the `tpm2-abrmd` service is running, start the IMA component using the comm
 
 `keylime_ima_emulator`
 
+## Access to Keylime components from the host
+
+To allow direct access to the Keylime components from the host machine, you can
+forward the ports for the various Keylime components by uncommenting the
+relevant lines in the Vagrantfile.
+
 ## License
+
 [Apache
 2.0](https://github.com/keylime/ansible-keylime-tpm-emulator/blob/master/LICENSE)
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,17 +51,30 @@ end
 
 Vagrant.configure("2") do |config|
   (1..instances).each do |i|
-    config.vm.define "keylime#{i}" do |keylime|
-      keylime.vm.box = "fedora/33-cloud-base"
+    config.vm.define "keylime-fedora#{i}" do |keylime|
+      keylime.vm.box = "fedora/35-cloud-base"
       # Should you require machines to share a private network
       # Note, you will need to create the network first within
       # your provider (VirtualBox / Libvirt etc)
       # keylime.vm.network :private_network, ip: "10.0.0.#{i}1"
+
+      # Uncomment the following to forward ports on the VM and
+      # allow access to Keylime components from the host machine.
       keylime.vm.network "forwarded_port", guest: 443, host: "844#{i}"
+      # Forward Cloud Verifier listen port:
+      #keylime.vm.network "forwarded_port", guest: 8881, host: "8881"
+      # Forward Cloud Verifier revocation port:
+      #keylime.vm.network "forwarded_port", guest: 8892, host: "8892"
+      # Forward registrar listen port:
+      #keylime.vm.network "forwarded_port", guest: 8890, host: "8890"
+      # Forward registrar TLS listen port:
+      #keylime.vm.network "forwarded_port", guest: 8891, host: "8891"
+      # Forward agent listen port:
+      #keylime.vm.network "forwarded_port", guest: 9002, host: "9002"
       if instances == 1
-        hostname = "keylime"
+        hostname = "keylime-fedora"
       else
-        hostname = "keylime#{i}"
+        hostname = "keylime-fedora#{i}"
       end
       keylime.vm.hostname = "#{hostname}"
       if defined? (repo)

--- a/roles/ansible-keylime-tpm20/tasks/git-repos.yml
+++ b/roles/ansible-keylime-tpm20/tasks/git-repos.yml
@@ -1,4 +1,4 @@
-- name: Clone keylime
+- name: Clone Keylime
   git:
     repo: https://github.com/keylime/keylime
     dest: /root/keylime

--- a/roles/ansible-keylime-tpm20/tasks/ibm-tpm.yml
+++ b/roles/ansible-keylime-tpm20/tasks/ibm-tpm.yml
@@ -28,52 +28,80 @@
 - name: Changing perm of "init_tpm_server", adding "+x"
   file: dest=/usr/local/bin/init_tpm_server mode=a+x
 
-- name: 'Set environment'
-  shell: "echo $TPM2TOOLS_TCTI"
-  environment:
-    TPM2TOOLS_TCTI: "tabrmd:bus_name=com.intel.tss2.Tabrmd"
-
 - name: Ensure tpm_server is not running
   command: pkill tpm_server
   ignore_errors: yes
+   
+- name:  Clear TPM on first use
+  command: init_tpm_server
+  become: yes
 
 - name: Start TPM Emulator
   command: /usr/local/bin/tpm_serverd
   become: yes
 
-- name: Enable tpm2_abrmd service and ensure it is not masked
+- name: Download ima_stub_service script tpm_with_ima.sh
+  get_url:
+    url: https://github.com/keylime/keylime/raw/master/ima_stub_service/tpm_with_ima.sh
+    dest: /usr/local/bin/tpm_with_ima.sh
+    mode: '0744'
+
+- name: Downloa ima_stub_service systemd service tpm_emulator.service
+  get_url:
+    url: https://github.com/keylime/keylime/raw/master/ima_stub_service/tpm_emulator.service
+    dest: /etc/systemd/system/tpm_emulator.service
+    mode: '0664'
+
+- name: Enable tpm_emulator systemd service and ensure it is not masked
   systemd:
-    name: tpm2-abrmd
+    name: tpm_emulator
     enabled: yes
     masked: no
 
-- name: Create a systemd drop-in directory for tpm2-abrmd
-  file:
-    dest: /etc/systemd/system/tpm2-abrmd.service.d/
-    state: directory
-    mode: '0755'
-    owner: root
-    group: root
-
-- name: Change TCTI to emulator in tpm2-abrmd unit
-  copy:
-    src: files/tpm2-abrmd.service.d/10-tcti-emulator.conf
-    dest: /etc/systemd/system/tpm2-abrmd.service.d/
-    owner: root
-    group: root
-    mode: '0644'
-
-- name: Remove ConditionPathExistsGlob from tpm2-abrmd unit
-  copy:
-    src: files/tpm2-abrmd.service.d/20-remove-conditionpathexistsglob.conf
-    dest: /etc/systemd/system/tpm2-abrmd.service.d/
-    owner: root
-    group: root
-    mode: '0644'
-
-- name: Reload / restart service tpm2-abrmd, in all cases
+- name: Reload / restart service tpm_emulator service, in all cases
   systemd:
-    name: tpm2-abrmd
+    name: tpm_emulator
     state: restarted
-    daemon_reload: yes
+#    daemon_reload: yes
 
+# We don't use abrmd anymore, commenting this out.
+#- name: 'Set environment'
+#  shell: "echo $TPM2TOOLS_TCTI"
+#  environment:
+#    TPM2TOOLS_TCTI: "tabrmd:bus_name=com.intel.tss2.Tabrmd"
+#
+#- name: Enable tpm2_abrmd service and ensure it is not masked
+#  systemd:
+#    name: tpm2-abrmd
+#    enabled: yes
+#    masked: no
+#
+#- name: Create a systemd drop-in directory for tpm2-abrmd
+#  file:
+#    dest: /etc/systemd/system/tpm2-abrmd.service.d/
+#    state: directory
+#    mode: '0755'
+#    owner: root
+#    group: root
+#
+#- name: Change TCTI to emulator in tpm2-abrmd unit
+#  copy:
+#    src: files/tpm2-abrmd.service.d/10-tcti-emulator.conf
+#    dest: /etc/systemd/system/tpm2-abrmd.service.d/
+#    owner: root
+#    group: root
+#    mode: '0644'
+#
+#- name: Remove ConditionPathExistsGlob from tpm2-abrmd unit
+#  copy:
+#    src: files/tpm2-abrmd.service.d/20-remove-conditionpathexistsglob.conf
+#    dest: /etc/systemd/system/tpm2-abrmd.service.d/
+#    owner: root
+#    group: root
+#    mode: '0644'
+#
+#- name: Reload / restart service tpm2-abrmd, in all cases
+#  systemd:
+#    name: tpm2-abrmd
+#    state: restarted
+#    daemon_reload: yes

--- a/roles/ansible-keylime-tpm20/tasks/packages.yml
+++ b/roles/ansible-keylime-tpm20/tasks/packages.yml
@@ -6,33 +6,55 @@
 - name: install prerequisite packages
   dnf:
       name:
+        # TPM tools
+        - tpm2-tools
+        - tpm2-tss
+        - tss2
+
+        # Python pre-in
         - git
-        - automake
-        - libtool
-        - autoconf
-        - autoconf-archive
-        - libstdc++-devel
+        - patch
+        - python3
+        - python3-devel
+        - python3-setuptools
+        - wget
+
+        # Python dependencies
         - gcc
-        - pkg-config
-        - uriparser-devel
-        - libgcrypt-devel
-        - dbus-devel
-        - glib2-devel
-        - compat-openssl10-devel
-        - libcurl-devel
-        - python3-pip
-        - python3-pyyaml
+        - gcc-c++
+        - openssl-devel
+        - procps-ng
+        - python3-alembic
+        - python3-cryptography
+        - python3-gnupg
         - python3-m2crypto
-        - python3-tornado
-        - python3-simplejson
+        - python3-packaging
+        - python3-pip
+        - python3-psutil
+        - python3-pyyaml
         - python3-requests
         - python3-sqlalchemy
-        - python3-alembic
-        - libselinux-python3
-        - yaml-cpp-devel
-        - procps-ng
-        - tpm2-tss
-        - tpm2-tools
-        - tpm2-abrmd
+        - python3-tornado
         - python3-zmq
+        - swig
+        - yaml-cpp-devel
+
+          # Build tools
+        - autoconf
+        - automake
+        - autoconf-archive
+        - doxygen
+        - dbus-devel
+        - gnulib-devel
+        - json-c-devel
+        - libgcrypt-devel
+        - libstdc++-devel
+        - libtool
+        - libuuid-devel
+        - m4
+        - make 
+        - openssl-devel
+        - pkg-config 
+        - uriparser-devel
+
       state: latest


### PR DESCRIPTION
Align on installer.sh:
- update packages task
- stop using abrmd

Note: creates a working Keylime VM, but exporting the following
environment variable is still needed to start keylime_agent:
export TPM2TOOLS_TCTI="mssim:port=2321"