### PR TITLE
Remove audio from VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,6 +83,7 @@ Vagrant.configure("2") do |config|
       keylime.vm.provider "virtualbox" do |v|
         v.memory = "#{memory}"
         v.cpus = "#{cpus}"
+        v.customize ["modifyvm", :id, "--audio", "none"]
       end
       keylime.vm.provider "libvirt" do |vb|
         vb.random :model => 'random'


### PR DESCRIPTION
This is needed for certain versions of VirtualBox if you
are using that as the Vagrant provider. Otherwise you can
get a weird error like:

Stderr: VBoxManage: error: Failed to construct device 'ichac97' instance #0 (VERR_CFGM_NOT_ENOUGH_SPACE)
VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component ConsoleWrap, interface IConsole

Signed-off-by: Michael Peters <mpeters@redhat.com>