### PR TITLE
Add support for Keylime's new config format

### DIFF
--- a/roles/ansible-keylime-tpm20/tasks/keylime.yml
+++ b/roles/ansible-keylime-tpm20/tasks/keylime.yml
@@ -15,6 +15,31 @@
     mode: 0644
     remote_src: yes
 
+- name: Create /etc/keylime for new-format config files
+  ansible.builtin.file:
+    path: /etc/keylime
+    state: directory
+    mode: 0755
+
+- name: Convert keylime.conf to new config format
+  shell: "/usr/bin/python3 convert_config.py"
+  args:
+    chdir: /root/keylime/scripts
+
+- name: Copy converted config files to /etc/keylime
+  copy:
+    src: "/root/keylime/scripts/{{ item }}.conf"
+    dest: /etc/keylime
+    mode: 0644
+    remote_src: yes
+  loop:
+    - agent
+    - verifier
+    - tenant
+    - registrar
+    - ca
+    - logging
+
 - name: Change require_ek_cert to false.
   lineinfile:
     path: /etc/keylime.conf


### PR DESCRIPTION
New since Keylime 6.5.0. Old config files won't work, so this should fix breakage with up-to-date Keylime clones.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>