### PR TITLE
Fix ima_emulator.service not starting correctly by running tpm2_startup -c

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -109,6 +109,7 @@ Vagrant.configure("2") do |config|
             end
         end
       end
+      keylime.vm.provision :shell, inline: "tpm2_startup -c && systemctl restart ima_emulator.service", run: "always"
     end
   end
 end


### PR DESCRIPTION
This should hopefully be a permanent fix for `ima_emulator.service` breaking on VM startup.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>