### PR TITLE
Add guidance on disabling ekcert checking for development

### DIFF
--- a/docs/vagrant-setup-guide-fedora.md
+++ b/docs/vagrant-setup-guide-fedora.md
@@ -151,6 +151,12 @@ The files and directories listed in this file will not be checked for integrity 
 /root/keylime-dev/*
 ```
 
+## (DEVELOPMENT ONLY) Disable `ekcert` checking
+
+By default, Keylime checks for an `ekcert` as part of the tenant running. While important in production, this often isn't necessary for development, so to get Keylime working easily it's possible to disable these checks by changing the Keylime tenant config file at `/etc/keylime/tenant.conf`.
+
+Look for `require_ek_cert`. By default, it should be `True`; for development purposes ONLY, set it to `False`.
+
 ## Start Keylime
 
 From your local machine, **open 4 terminals** to run and monitor 4 different processes (verifier, registrar, agent, tenant). After you open each terminal, run the following commands on each one:

--- a/roles/ansible-keylime-tpm20/tasks/keylime.yml
+++ b/roles/ansible-keylime-tpm20/tasks/keylime.yml
@@ -15,6 +15,18 @@
     mode: 0644
     remote_src: yes
 
+- name: Change require_ek_cert to false.
+  lineinfile:
+    path: /etc/keylime.conf
+    regexp: '^require_ek_cert'
+    line: require_ek_cert = False
+
+- name: Change ca_implementation to openssl.
+  lineinfile:
+    path: /etc/keylime.conf
+    regexp: '^ca_implementation'
+    line: ca_implementation = openssl
+
 - name: Create /etc/keylime for new-format config files
   ansible.builtin.file:
     path: /etc/keylime
@@ -39,15 +51,3 @@
     - registrar
     - ca
     - logging
-
-- name: Change require_ek_cert to false.
-  lineinfile:
-    path: /etc/keylime.conf
-    regexp: '^require_ek_cert'
-    line: require_ek_cert = False
-
-- name: Change ca_implementation to openssl.
-  lineinfile:
-    path: /etc/keylime.conf
-    regexp: '^ca_implementation'
-    line: ca_implementation = openssl


### PR DESCRIPTION
For ease of use, add guidance on disabling `ekcert` checking for development purposes.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>