### PR TITLE
Fix keylime.conf changes not being reflected in new config files

### DIFF
--- a/roles/ansible-keylime-tpm20/tasks/keylime.yml
+++ b/roles/ansible-keylime-tpm20/tasks/keylime.yml
@@ -15,6 +15,18 @@
     mode: 0644
     remote_src: yes
 
+- name: Change require_ek_cert to false.
+  lineinfile:
+    path: /etc/keylime.conf
+    regexp: '^require_ek_cert'
+    line: require_ek_cert = False
+
+- name: Change ca_implementation to openssl.
+  lineinfile:
+    path: /etc/keylime.conf
+    regexp: '^ca_implementation'
+    line: ca_implementation = openssl
+
 - name: Create /etc/keylime for new-format config files
   ansible.builtin.file:
     path: /etc/keylime
@@ -39,15 +51,3 @@
     - registrar
     - ca
     - logging
-
-- name: Change require_ek_cert to false.
-  lineinfile:
-    path: /etc/keylime.conf
-    regexp: '^require_ek_cert'
-    line: require_ek_cert = False
-
-- name: Change ca_implementation to openssl.
-  lineinfile:
-    path: /etc/keylime.conf
-    regexp: '^ca_implementation'
-    line: ca_implementation = openssl


### PR DESCRIPTION
As it turns out, the fix for supporting new-format config files in #65 happened too early in `keylime.yml`. It converted config files to the new format before certain values (like disabling `ekcert` checking for development) happened. This fixes that.

Signed-off-by: Mark Bestavros <mbestavr@redhat.com>