### PR TITLE
Fix doc use of unknown keylime_node command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ keylime_registrar
 
 keylime_agent
 
-keylime_node
+keylime_tenant
 ```
 
 Note: you will most likely need to export the right TPM2TOOLS_TCTI environment


### PR DESCRIPTION
I assume this was an old name for keylime_tenant, but regardless it should be changed.
Fixes issue #42