### PR TITLE
Use swtpm in chardev mode

### DIFF
--- a/roles/tpm_setup/files/ima_emulator.service
+++ b/roles/tpm_setup/files/ima_emulator.service
@@ -4,7 +4,7 @@ After=network.target tpm_emulator.service
 Requires=tpm_emulator.service
 
 [Service]
-Environment=TPM2TOOLS_TCTI="swtpm:port=2321"
+Environment=TPM2TOOLS_TCTI="device:/dev/tpm0"
 ExecStart=/usr/bin/bash -c "keylime_ima_emulator --hash_algs sha256 --ima-hash-alg sha1"
 
 [Install]

--- a/roles/tpm_setup/files/tpm_emulator.service
+++ b/roles/tpm_setup/files/tpm_emulator.service
@@ -3,9 +3,11 @@ Description=IBM TPM emulator service for Keylime
 After=network.target
 
 [Service]
-Environment=TPM_PATH=/var/run/tpm0
-ExecStartPre=mkdir -p /var/run/tpm0 && chmod 700 /var/run/tpm0
-ExecStart=swtpm socket --tpmstate dir=/var/run/tpm0 --tpm2 --server type=tcp,port=2321 --ctrl type=tcp,port=2322 --flags not-need-init,startup-clear
+ExecStartPre=rm -rf /var/run/tpm0
+ExecStartPre=mkdir -p /var/run/tpm0
+ExecStartPre=chmod 700 /var/run/tpm0
+ExecStartPre=swtpm_setup --tpm2 --tpmstate /var/run/tpm0 --createek --decryption --create-ek-cert --create-platform-cert --display
+ExecStart=swtpm chardev --tpm2 --vtpm-proxy --tpmstate dir=/var/run/tpm0
 
 [Install]
 WantedBy=default.target

--- a/roles/tpm_setup/tasks/main.yml
+++ b/roles/tpm_setup/tasks/main.yml
@@ -1,6 +1,8 @@
 - name: Install SW TPM
   yum:
-    name: swtpm
+    name:
+      - swtpm
+      - swtpm-tools
     state: present
 
 - name: Set TPM2TOOLS_TCTI environment variable globally
@@ -8,7 +10,13 @@
     dest: /etc/environment
     state: present
     regexp: '^TPM2TOOLS_TCTI'
-    line: 'TPM2TOOLS_TCTI=swtpm:port=2321'
+    line: 'TPM2TOOLS_TCTI=device:/dev/tpm0'
+
+- name: Enable the vTPM proxy kernel module
+  modprobe:
+    name: tpm_vtpm_proxy
+    state: present
+    persistent: present
 
 - name: Install TPM Emulator service
   copy:
@@ -27,7 +35,7 @@
 - name: IMA config directory
   file: path=/etc/ima state=directory
 
-- name: IMA demo policy
+- name: IMA policy
   copy:
     src: ima-policy
     dest: /etc/ima/ima-policy


### PR DESCRIPTION
This uses the tpm_vtpm_proxy kernel module to expose the swtpm as /dev/tpm0 so it appears more like a real tpm device.

Makes it easier to use the rust agent as well.