### PR TITLE
Update vagrant setup to Fedora 41

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ end
 Vagrant.configure("2") do |config|
   (1..instances).each do |i|
     config.vm.define "keylime-fedora#{i}" do |keylime|
-      keylime.vm.box = "fedora/38-cloud-base"
+      keylime.vm.box = "fedora/41-cloud-base"
       # Should you require machines to share a private network
       # Note, you will need to create the network first within
       # your provider (VirtualBox / Libvirt etc)
@@ -65,6 +65,7 @@ Vagrant.configure("2") do |config|
       # Uncomment the following to forward ports on the VM and
       # allow access to Keylime components from the host machine.
       keylime.vm.network "forwarded_port", guest: 443, host: "844#{i}"
+
       # Forward Cloud Verifier listen port:
       #keylime.vm.network "forwarded_port", guest: 8881, host: "8881"
       # Forward Cloud Verifier revocation port:

--- a/playbook.yml
+++ b/playbook.yml
@@ -2,10 +2,6 @@
 - hosts: all
   become: true
   pre_tasks:
-    - name: Put SELinux in permissive mode, logging actions that would be blocked.
-      selinux:
-        policy: targeted
-        state: permissive
     - name: Ensure Python 3 is available
       dnf:
         name: python3
@@ -13,7 +9,11 @@
     - name: Install libselinux-python3
       dnf:
         name: libselinux-python3
-        state: present
+        state: present    
+    - name: Put SELinux in permissive mode, logging actions that would be blocked.
+      selinux:
+        policy: targeted
+        state: permissive
   roles:
     # pulled from https://github.com/keylime/ansible-keylime/tree/master/roles/ansible-keylime during vagrant provisioning
     - ansible-keylime

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -15,7 +15,7 @@ repo: '/path/to/keylime'
 
 # Location of your local Keylime Rust agent git repository to sync into the virtual
 # machine. This allows you to test your code within the VM.
-agent-repo: '/path/to/keylime-rust'
+agent-repo: '/path/to/rust-keylime'
 
 # Set verbosity during Ansible provisioning.
 verbose: false


### PR DESCRIPTION
This also includes:

+ Change order of pre-tasks in playbook.yml to fix "No module named selinux" error after version bump.
+ Renames filepath for clarity in vagrant_variables.yml.sample

Fixes issue #83